### PR TITLE
Adds changes to bring inline with TinyCLR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # jsonnetmf
-JSON serialize/deserialize for netmf
+A JSON serialization and deserialization library for use in .Net MicroFramwwork and TinyCLR.
+
+See License in the Root for distribution rights.

--- a/src/JsonNetmf/GHIElectronics.TinyCLR.Data.Json/GHIElectronics.TinyCLR.Data.Json.csproj
+++ b/src/JsonNetmf/GHIElectronics.TinyCLR.Data.Json/GHIElectronics.TinyCLR.Data.Json.csproj
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)..\mscorlib.props" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4B7A2C87-ABC9-4B99-A500-DB147F909945}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>GHIElectronics.TinyCLR.Data.Json</RootNamespace>
+    <AssemblyName>GHIElectronics.TinyCLR.Data.Json</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{A1948822-69DD-4150-919B-F3F42EFB71CC};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\JsonNetmf.Shared\BsonTypes.cs" />
+    <Compile Include="..\JsonNetmf.Shared\JArray.cs" />
+    <Compile Include="..\JsonNetmf.Shared\JObject.cs" />
+    <Compile Include="..\JsonNetmf.Shared\JProperty.cs" />
+    <Compile Include="..\JsonNetmf.Shared\JsonConverter.cs" />
+    <Compile Include="..\JsonNetmf.Shared\JToken.cs" />
+    <Compile Include="..\JsonNetmf.Shared\JValue.cs" />
+    <Compile Include="..\JsonNetmf.Shared\SerializationUtilities.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="..\JsonNetmf.Shared\StringExtensions.cs" />
+    <Compile Include="..\JsonNetmf.Shared\TimeExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="GHIElectronics.TinyCLR.Data.Json.nuspec" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GHIElectronics.TinyCLR.IO\GHIElectronics.TinyCLR.IO.csproj">
+      <Project>{313AEC8E-2B47-4A1A-ACE2-A766D076B2AE}</Project>
+      <Name>GHIElectronics.TinyCLR.IO</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\GHIElectronics.Tools.NuGetPacker.1.0.3\build\GHIElectronics.Tools.NuGetPacker.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GHIElectronics.Tools.NuGetPacker.1.0.3\build\GHIElectronics.Tools.NuGetPacker.targets'))" />    
+  </Target>
+  <Import Project="..\packages\GHIElectronics.Tools.NuGetPacker.1.0.3\build\GHIElectronics.Tools.NuGetPacker.targets" Condition="Exists('..\packages\GHIElectronics.Tools.NuGetPacker.1.0.3\build\GHIElectronics.Tools.NuGetPacker.targets')" />  
+</Project>

--- a/src/JsonNetmf/GHIElectronics.TinyCLR.Data.Json/GHIElectronics.TinyCLR.Data.Json.nuspec
+++ b/src/JsonNetmf/GHIElectronics.TinyCLR.Data.Json/GHIElectronics.TinyCLR.Data.Json.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>GHIElectronics.TinyCLR.Data.Json</id>
+    <version>2.0.0-preview5</version>
+    <authors>GHI Electronics, LLC</authors>
+    <owners>GHI Electronics, LLC</owners>
+    <projectUrl>https://ghielectronics.com/</projectUrl>
+    <iconUrl>http://files.ghielectronics.com/downloads/Logos/GHIElectronicsTinyCLRNuGet.png</iconUrl>
+    <licenseUrl>http://files.ghielectronics.com/downloads/TinyCLR/License.txt</licenseUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>The JSON library for TinyCLR OS.</description>
+    <copyright>Copyright GHI Electronics, LLC 2020</copyright>
+    <tags>TinyCLR TinyCLROS</tags>
+    <dependencies>
+      <dependency id="GHIElectronics.TinyCLR.Core" version="2.0.0-preview5" />
+      <dependency id="GHIElectronics.TinyCLR.IO" version="2.0.0-preview5" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="$TargetDir$GHIElectronics.TinyCLR.Data.Json.dll" target="lib\net452" />
+  </files>
+</package>

--- a/src/JsonNetmf/GHIElectronics.TinyCLR.Data.Json/Properties/AssemblyInfo.cs
+++ b/src/JsonNetmf/GHIElectronics.TinyCLR.Data.Json/Properties/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("GHIElectronics.TinyCLR.Data.Json")]
+[assembly: AssemblyDescription("TinyCLR OS JSON library.")]
+[assembly: AssemblyCompany("GHI Electronics, LLC")]
+[assembly: AssemblyProduct("TinyCLR OS")]
+[assembly: AssemblyCopyright("Copyright © GHI Electronics, LLC 2020")]
+[assembly: ComVisible(false)]
+[assembly: Guid("4B7A2C87-ABC9-4B99-A500-DB147F909945")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.50000")]
+[assembly: AssemblyInformationalVersion("2.0.0-preview5")]

--- a/src/JsonNetmf/GHIElectronics.TinyCLR.Data.Json/packages.config
+++ b/src/JsonNetmf/GHIElectronics.TinyCLR.Data.Json/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>  
+  <package id="GHIElectronics.Tools.NuGetPacker" version="1.0.3" targetFramework="net452" developmentDependency="true" />
+  <package id="NuGet.CommandLine" version="4.5.1" targetFramework="net452" developmentDependency="true" />
+</packages>

--- a/src/JsonNetmf/JsonNetmf.Shared/BsonTypes.cs
+++ b/src/JsonNetmf/JsonNetmf.Shared/BsonTypes.cs
@@ -1,7 +1,11 @@
 ﻿using System;
 using System.Text;
 
+#if (MF_FRAMEWORK_VERSION_V4_3 || MF_FRAMEWORK_VERSION_V4_4)
 namespace PervasiveDigital.Json
+#else
+namespace GHIElectronics.TinyCLR.Data.Json
+#endif
 {
     public enum BsonTypes : byte
     {

--- a/src/JsonNetmf/JsonNetmf.Shared/JArray.cs
+++ b/src/JsonNetmf/JsonNetmf.Shared/JArray.cs
@@ -1,11 +1,12 @@
-﻿// (c) Pervasive Digital LLC
-// Use of this code and resulting binaries is permitted only under the
-// terms of a written license.
-using System;
+﻿using System;
 using System.Collections;
 using System.Text;
 
+#if (MF_FRAMEWORK_VERSION_V4_3 || MF_FRAMEWORK_VERSION_V4_4)
 namespace PervasiveDigital.Json
+#else
+namespace GHIElectronics.TinyCLR.Data.Json
+#endif
 {
 	public class JArray : JToken
 	{

--- a/src/JsonNetmf/JsonNetmf.Shared/JObject.cs
+++ b/src/JsonNetmf/JsonNetmf.Shared/JObject.cs
@@ -1,12 +1,13 @@
-﻿// (c) Pervasive Digital LLC
-// Use of this code and resulting binaries is permitted only under the
-// terms of a written license.
 using System;
 using System.Collections;
 using System.Reflection;
 using System.Text;
 
+#if (MF_FRAMEWORK_VERSION_V4_3 || MF_FRAMEWORK_VERSION_V4_4)
 namespace PervasiveDigital.Json
+#else
+namespace GHIElectronics.TinyCLR.Data.Json
+#endif
 {
 	public class JObject : JToken
 	{
@@ -22,6 +23,10 @@ namespace PervasiveDigital.Json
 				_members.Add(value.Name.ToLower(), value);
 			}
 		}
+
+#if (!MF_FRAMEWORK_VERSION_V4_3 || !MF_FRAMEWORK_VERSION_V4_4)
+        public bool Contains(string name) => this._members.Contains(name.ToLower());
+#endif
 
 		public ICollection Members
 		{
@@ -51,8 +56,19 @@ namespace PervasiveDigital.Json
 					if (m.ReturnType.IsArray)
 						result._members.Add(name.ToLower(), new JProperty(name, JArray.Serialize(m.ReturnType, methodResult)));
 					else
-						result._members.Add(name.ToLower(), new JProperty(name, JObject.Serialize(m.ReturnType, methodResult)));
-				}
+#if (!MF_FRAMEWORK_VERSION_V4_3 || !MF_FRAMEWORK_VERSION_V4_4)
+					{
+						if (m.ReturnType.IsValueType || m.ReturnType == typeof(string))
+                        {
+                            result._members.Add(name.ToLower(), new JProperty(name, JValue.Serialize(m.ReturnType, methodResult)));
+                        }
+                        else
+#endif
+						{
+                            result._members.Add(name.ToLower(), new JProperty(name, JObject.Serialize(m.ReturnType, methodResult)));
+                        }
+                    }
+                }
 			}
 
 			var fields = type.GetFields();

--- a/src/JsonNetmf/JsonNetmf.Shared/JProperty.cs
+++ b/src/JsonNetmf/JsonNetmf.Shared/JProperty.cs
@@ -1,10 +1,11 @@
-﻿// (c) Pervasive Digital LLC
-// Use of this code and resulting binaries is permitted only under the
-// terms of a written license.
-using System;
+﻿using System;
 using System.Text;
 
+#if (MF_FRAMEWORK_VERSION_V4_3 || MF_FRAMEWORK_VERSION_V4_4)
 namespace PervasiveDigital.Json
+#else
+namespace GHIElectronics.TinyCLR.Data.Json
+#endif
 {
 	public class JProperty : JToken
 	{

--- a/src/JsonNetmf/JsonNetmf.Shared/JToken.cs
+++ b/src/JsonNetmf/JsonNetmf.Shared/JToken.cs
@@ -1,11 +1,12 @@
-﻿// (c) Pervasive Digital LLC
-// Use of this code and resulting binaries is permitted only under the
-// terms of a written license.
-using System;
+﻿using System;
 using System.Text;
 using System.Threading;
 
+#if (MF_FRAMEWORK_VERSION_V4_3 || MF_FRAMEWORK_VERSION_V4_4)
 namespace PervasiveDigital.Json
+#else
+namespace GHIElectronics.TinyCLR.Data.Json
+#endif
 {
 	public abstract class JToken
 	{

--- a/src/JsonNetmf/JsonNetmf.Shared/JValue.cs
+++ b/src/JsonNetmf/JsonNetmf.Shared/JValue.cs
@@ -1,84 +1,93 @@
-﻿// (c) Pervasive Digital LLC
-// Use of this code and resulting binaries is permitted only under the
-// terms of a written license.
 using System;
 
+#if (MF_FRAMEWORK_VERSION_V4_3 || MF_FRAMEWORK_VERSION_V4_4)
 namespace PervasiveDigital.Json
+#else
+namespace GHIElectronics.TinyCLR.Data.Json
+#endif
 {
-	public class JValue : JToken
-	{
-		public JValue()
-		{
-		}
+    public class JValue : JToken
+    {
+        public JValue()
+        {
+        }
 
-		public JValue(object value)
-		{
-			this.Value = value;
-		}
+        public JValue(object value)
+        {
+            this.Value = value;
+        }
 
-		public object Value { get; set; }
+        public object Value { get; set; }
 
-		public static JValue Serialize(Type type, object oValue)
-		{
-			return new JValue()
-			{
-				Value = oValue
-			};
-		}
+        public static JValue Serialize(Type type, object oValue)
+        {
+            return new JValue()
+            {
+                Value = oValue
+            };
+        }
 
-		public override string ToString()
-		{
-			EnterSerialization();
-			try
-			{
-				if (Value == null)
-					return "null";
+        public override string ToString()
+        {
+            EnterSerialization();
+            try
+            {
+                if (Value == null)
+                    return "null";
 
-				var type = this.Value.GetType();
-				if (type == typeof(string) || type == typeof(char))
-					return "\"" + this.Value.ToString() + "\"";
-				else if (type == typeof(DateTime))
-					return "\"" + DateTimeExtensions.ToIso8601(((DateTime)this.Value)) + "\"";
-				else
-					return this.Value.ToString();
-			}
-			finally
-			{
-				ExitSerialization();
-			}
-		}
+                var type = this.Value.GetType();
+                if (type == typeof(string) || type == typeof(char))
+                    return "\"" + this.Value.ToString() + "\"";
+                else if (type == typeof(DateTime))
+                    return "\"" + DateTimeExtensions.ToIso8601(((DateTime)this.Value)) + "\"";
+#if (!MF_FRAMEWORK_VERSION_V4_3 && !MF_FRAMEWORK_VERSION_V4_4)
+                else if (type == typeof(bool))
+                    return this.Value.ToString().ToLower();
+#endif
+                else
+                    return this.Value.ToString();
+            }
+            finally
+            {
+                ExitSerialization();
+            }
+        }
 
-		public override int GetBsonSize()
-		{
-			if (this.Value == null)
-				return 0;
+        public override int GetBsonSize()
+        {
+            if (this.Value == null)
+                return 0;
 
-			var type = this.Value.GetType();
-			if (type == typeof(double))
-				return 8;
-			else if (type == typeof(string))
-				return ((string)this.Value).Length + 1;  // preamble, strlen, nul
-			if (type == typeof(char))
-				return 1 + 1;  // strlen==1, nul
-			else if (type == typeof(Int32) || type == typeof(UInt32))
-				return 4;
-			else if (type == typeof(Int64) || type == typeof(UInt64))
-				return 8;
-			else if (type == typeof(DateTime))
-				return 8;
-			else if (type == typeof(bool))
-				return 1;
-			else
-				throw new Exception("Unsupported type");
-		}
+            var type = this.Value.GetType();
+            if (type == typeof(double))
+                return 8;
+            else if (type == typeof(string))
+                return ((string)this.Value).Length + 1;  // preamble, strlen, nul
+            if (type == typeof(char))
+                return 1 + 1;  // strlen==1, nul
+            else if (type == typeof(Int32) || type == typeof(UInt32))
+                return 4;
+#if (!MF_FRAMEWORK_VERSION_V4_3 && !MF_FRAMEWORK_VERSION_V4_4)
+            else if (type == typeof(Int64) || type == typeof(UInt64))
+#else
+            else if (type == typeof(Int64) || type == typeof(UInt64) || type == typeof(float) || type == typeof(double))
+#endif
+                return 8;
+            else if (type == typeof(DateTime))
+                return 8;
+            else if (type == typeof(bool))
+                return 1;
+            else
+                throw new Exception("Unsupported type");
+        }
 
-		public override int GetBsonSize(string ename)
-		{
-			return 1 + ename.Length + 1 + this.GetBsonSize();
-		}
+        public override int GetBsonSize(string ename)
+        {
+            return 1 + ename.Length + 1 + this.GetBsonSize();
+        }
 
-		public override void ToBson(byte[] buffer, ref int offset)
-		{
+        public override void ToBson(byte[] buffer, ref int offset)
+        {
             if (buffer != null)
             {
                 if (this.Value != null)
@@ -88,7 +97,7 @@ namespace PervasiveDigital.Json
             {
                 offset += this.GetBsonSize();
             }
-		}
+        }
 
         public override BsonTypes GetBsonType()
         {
@@ -96,7 +105,7 @@ namespace PervasiveDigital.Json
                 return BsonTypes.BsonNull;
 
             var type = this.Value.GetType();
-            if (type == typeof(double))
+            if (type == typeof(double) || type == typeof(float))
                 return BsonTypes.BsonDouble;
             else if (type == typeof(string))
                 return BsonTypes.BsonString;

--- a/src/JsonNetmf/JsonNetmf.Shared/JsonConverter.cs
+++ b/src/JsonNetmf/JsonNetmf.Shared/JsonConverter.cs
@@ -1,127 +1,145 @@
-﻿// (c) Pervasive Digital LLC
-// Use of this code and resulting binaries is permitted only under the
-// terms of a written license.
 using System;
 using System.Collections;
 using System.IO;
 using System.Reflection;
 using System.Text;
 using System.Threading;
+
+#if (MF_FRAMEWORK_VERSION_V4_3 || MF_FRAMEWORK_VERSION_V4_4)
 using Microsoft.SPOT;
 
 namespace PervasiveDigital.Json
+#else
+using System.Diagnostics;
+
+namespace GHIElectronics.TinyCLR.Data.Json
+#endif
 {
-	// The protocol mantra: Be strict in what you emit, and generous in what you accept.
+    // The protocol mantra: Be strict in what you emit, and generous in what you accept.
 
-	public delegate object InstanceFactory(string instancePath, string fieldName, int length);
+    public delegate object InstanceFactory(string instancePath, string fieldName, int length);
 
-	public static class JsonConverter
-	{
-		private enum TokenType
-		{
-			LBrace, RBrace, LArray, RArray, Colon, Comma, String, Number, Date, Error,
-			True, False, Null, End
-		}
+    public static class JsonConverter
+    {
+        private enum TokenType
+        {
+            LBrace, RBrace, LArray, RArray, Colon, Comma, String, Number, Date, Error,
+            True, False, Null, End
+        }
 
-		private struct LexToken
-		{
-			public TokenType TType;
-			public string TValue;
-		}
+        private struct LexToken
+        {
+            public TokenType TType;
+            public string TValue;
+        }
 
-		public class SerializationCtx
-		{
-			public int Indent;
-		}
+        public class SerializationCtx
+        {
+            public int Indent;
+        }
 
-		public static SerializationCtx SerializationContext = null;
-		public static object SyncObj = new object();
+        public static SerializationCtx SerializationContext = null;
+        public static object SyncObj = new object();
 
-		public static JToken Serialize(object oSource)
-		{
-			var type = oSource.GetType();
-			if (type.IsArray)
-				return JArray.Serialize(type, oSource);
-			else
-				return JObject.Serialize(type, oSource);
-		}
+        public static JToken Serialize(object oSource)
+        {
+            var type = oSource.GetType();
+            if (type.IsArray)
+                return JArray.Serialize(type, oSource);
+            else
+                return JObject.Serialize(type, oSource);
+        }
 
-		public static object DeserializeObject(string sourceString, Type type, InstanceFactory factory = null)
-		{
-			var dserResult = Deserialize(sourceString);
-			return PopulateObject(dserResult, type, "/", factory);
-		}
+        public static object DeserializeObject(string sourceString, Type type, InstanceFactory factory = null)
+        {
+            var dserResult = Deserialize(sourceString);
+            return PopulateObject(dserResult, type, "/", factory);
+        }
 
-		public static object DeserializeObject(Stream stream, Type type, InstanceFactory factory = null)
-		{
-			var dserResult = Deserialize(stream);
-			return PopulateObject(dserResult, type, "/", factory);
-		}
+        public static object DeserializeObject(Stream stream, Type type, InstanceFactory factory = null)
+        {
+            var dserResult = Deserialize(stream);
+            return PopulateObject(dserResult, type, "/", factory);
+        }
 
-		public static object DeserializeObject(StreamReader sr, Type type, InstanceFactory factory = null)
-		{
-			var dserResult = Deserialize(sr);
-			return PopulateObject(dserResult, type, "/", factory);
-		}
+        public static object DeserializeObject(StreamReader sr, Type type, InstanceFactory factory = null)
+        {
+            var dserResult = Deserialize(sr);
+            return PopulateObject(dserResult, type, "/", factory);
+        }
 
-		private static object PopulateObject(JToken root, Type type, string path, InstanceFactory factory)
-		{
-			if (root is JObject)
-			{
-				object instance = null;
-				if (type == null)
-				{
-					instance = factory(path, null, -1);
-					type = instance.GetType();
-				}
-				if (instance == null)
-					instance = AppDomain.CurrentDomain.CreateInstanceAndUnwrap(type.Assembly.FullName, type.FullName);
-				if (instance == null)
-					throw new Exception("failed to create target instance");
-				var jobj = (JObject)root;
-				foreach (var item in jobj.Members)
-				{
-					var prop = (JProperty)item;
-					MethodInfo method = null;
-					Type itemType = null;
-					var field = type.GetField(prop.Name);
-					if (field != null)
-					{
-						itemType = field.FieldType;
-					}
-					else
-					{
-						method = type.GetMethod("get_" + prop.Name);
-						itemType = method.ReturnType;
-						method = type.GetMethod("set_" + prop.Name);
-					}
+        private static object PopulateObject(JToken root, Type type, string path, InstanceFactory factory)
+        {
+            if (root is JObject)
+            {
+                object instance = null;
+                if (type == null)
+                {
+                    instance = factory(path, null, -1);
+                    type = instance.GetType();
+                }
+                if (instance == null)
+                    instance = AppDomain.CurrentDomain.CreateInstanceAndUnwrap(type.Assembly.FullName, type.FullName);
+                if (instance == null)
+                    throw new Exception("failed to create target instance");
+                var jobj = (JObject)root;
+                foreach (var item in jobj.Members)
+                {
+                    var prop = (JProperty)item;
+                    MethodInfo method = null;
+                    Type itemType = null;
+                    var field = type.GetField(prop.Name);
+                    if (field != null)
+                    {
+                        itemType = field.FieldType;
+                    }
+                    else
+                    {
+                        method = type.GetMethod("get_" + prop.Name);
+#if (!MF_FRAMEWORK_VERSION_V4_3 && !MF_FRAMEWORK_VERSION_V4_4)
+                        if (method == null)
+                        {
+                            continue;
+                        }
+#endif
+                        itemType = method.ReturnType;
+                        method = type.GetMethod("set_" + prop.Name);
+                    }
 
-					if (itemType != null)
-					{
-						if (prop.Value is JObject)
-						{
-							var childpath = path;
-							if (childpath[childpath.Length - 1] != '/')
-								childpath = childpath + '/' + prop.Name;
-							else
-								childpath += prop.Name;
-							var child = PopulateObject(prop.Value, itemType, childpath, factory);
-							if (field != null)
-								field.SetValue(instance, child);
-							else
-								method.Invoke(instance, new object[] { child });
-						}
-						else if (prop.Value is JValue)
-						{
-							if (field != null)
-							{
-								if (itemType != typeof(DateTime))
-								{
-									field.SetValue(instance, ((JValue)prop.Value).Value);
-								}
-								else
-								{
-									DateTime dt;
+                    if (itemType != null)
+                    {
+                        if (prop.Value is JObject)
+                        {
+                            var childpath = path;
+                            if (childpath[childpath.Length - 1] != '/')
+                                childpath = childpath + '/' + prop.Name;
+                            else
+                                childpath += prop.Name;
+                            var child = PopulateObject(prop.Value, itemType, childpath, factory);
+                            if (field != null)
+                                field.SetValue(instance, child);
+                            else
+                                method.Invoke(instance, new object[] { child });
+                        }
+                        else if (prop.Value is JValue)
+                        {
+                            if (field != null)
+                            {
+#if (!MF_FRAMEWORK_VERSION_V4_3 && !MF_FRAMEWORK_VERSION_V4_4)
+                                if (itemType == typeof(float))
+                                {
+                                    field.SetValue(instance, (float)((double)((JValue)prop.Value).Value));
+                                }
+
+                                else
+#endif 
+                                if (itemType != typeof(DateTime))
+                                {
+                                    field.SetValue(instance, ((JValue)prop.Value).Value);
+                                }
+                                else
+                                {
+                                    DateTime dt;
                                     var sdtValue = ((JValue)prop.Value).Value;
                                     if (sdtValue is DateTime)
                                     {
@@ -135,137 +153,150 @@ namespace PervasiveDigital.Json
                                         else
                                             dt = DateTimeExtensions.FromIso8601(sdt);
                                     }
-									field.SetValue(instance, dt);
-								}
-							}
-							else
-							{
-								if (itemType != typeof(DateTime))
-								{
-									method.Invoke(instance, new object[] { ((JValue)prop.Value).Value });
-								}
-								else
-								{
-									DateTime dt;
-									var sdt = ((JValue)prop.Value).Value.ToString();
-									if (sdt.Contains("Date("))
-										dt = DateTimeExtensions.FromASPNetAjax(sdt);
-									else
-										dt = DateTimeExtensions.FromIso8601(sdt);
+                                    field.SetValue(instance, dt);
+                                }
+                            }
+                            else
+                            {
+#if (!MF_FRAMEWORK_VERSION_V4_3 && !MF_FRAMEWORK_VERSION_V4_4)
+                                if (itemType == typeof(float)) {
+                                    method.Invoke(instance, new object[] { (float)((double)((JValue)prop.Value).Value) });
+                                }
+                                else
+#endif
+                                if (itemType != typeof(DateTime))
+                                {
+                                    method.Invoke(instance, new object[] { ((JValue)prop.Value).Value });
+                                }
+                                else
+                                {
+                                    DateTime dt;
+                                    var sdt = ((JValue)prop.Value).Value.ToString();
+                                    if (sdt.Contains("Date("))
+                                        dt = DateTimeExtensions.FromASPNetAjax(sdt);
+                                    else
+                                        dt = DateTimeExtensions.FromIso8601(sdt);
 
-									method.Invoke(instance, new object[] { dt });
-								}
-							}
-						}
-						else if (prop.Value is JArray)
-						{
-							if (factory == null)
-								throw new NotSupportedException("You must provide an instance factory if you want to populate objects that have arrays in them");
+                                    method.Invoke(instance, new object[] { dt });
+                                }
+                            }
+                        }
+                        else if (prop.Value is JArray)
+                        {
+                            if (factory == null)
+                                throw new NotSupportedException("You must provide an instance factory if you want to populate objects that have arrays in them");
 
-							var jarray = (JArray)prop.Value;
-							var list = new ArrayList();
-							var array = (Array)factory(path, prop.Name, jarray.Length);
-							//var array = Array.CreateInstance(field.FieldType.GetElementType(), jarray.Length);
-							foreach (var elem in jarray.Items)
-							{
-								if (elem is JValue)
-									list.Add(((JValue)elem).Value);
-								else
-								{
-									var arrayObj = PopulateObject(elem, null, path + "/" + prop.Name, factory);
-									list.Add(arrayObj);
-								}
-							}
-							list.CopyTo(array);
-							if (field != null)
-								field.SetValue(instance, array);
-							else
-								method.Invoke(instance, new object[] { array });
-						}
-					}
-				}
-				return instance;
-			}
-			else if (root is JArray)
-			{
+                            var jarray = (JArray)prop.Value;
+                            var list = new ArrayList();
+                            var array = (Array)factory(path, prop.Name, jarray.Length);
+                            //var array = Array.CreateInstance(field.FieldType.GetElementType(), jarray.Length);
+                            foreach (var elem in jarray.Items)
+                            {
+                                if (elem is JValue)
+                                    list.Add(((JValue)elem).Value);
+                                else
+                                {
+                                    var arrayObj = PopulateObject(elem, null, path + "/" + prop.Name, factory);
+                                    list.Add(arrayObj);
+                                }
+                            }
+                            list.CopyTo(array);
+                            if (field != null)
+                                field.SetValue(instance, array);
+                            else
+                                method.Invoke(instance, new object[] { array });
+                        }
+                    }
+                }
+                return instance;
+            }
+            else if (root is JArray)
+            {
                 var elemType = type.GetElementType();
-				if (elemType == null && factory == null)
-					throw new NotSupportedException("You must provide an instance factory if you want to populate objects that have arrays in them");
+                if (elemType == null && factory == null)
+                    throw new NotSupportedException("You must provide an instance factory if you want to populate objects that have arrays in them");
 
-				var jarray = (JArray)root;
-				var list = new ArrayList();
+                var jarray = (JArray)root;
+                var list = new ArrayList();
 
                 Array array;
-                if (elemType!=null)
-				    array = Array.CreateInstance(type.GetElementType(), jarray.Length);
+                if (elemType != null)
+                    array = Array.CreateInstance(type.GetElementType(), jarray.Length);
                 else
-    				array = (Array)factory(path, null, jarray.Length);
-	
+                    array = (Array)factory(path, null, jarray.Length);
+
                 foreach (var item in jarray.Items)
-				{
-					if (item is JValue)
-						list.Add(((JValue)item).Value);
-					else
-					{
-						var arrayObj = PopulateObject(item, null, path, factory);
-						list.Add(arrayObj);
-					}
-				}
-				list.CopyTo(array);
-				return array;
-			}
-			return null;
-		}
+                {
+                    if (item is JValue)
+                        list.Add(((JValue)item).Value);
+                    else
+                    {
+                        var arrayObj = PopulateObject(item, null, path, factory);
+                        list.Add(arrayObj);
+                    }
+                }
+                list.CopyTo(array);
+                return array;
+            }
+            return null;
+        }
 
-		public static JToken Deserialize(string sourceString)
-		{
-			var data = Encoding.UTF8.GetBytes(sourceString);
-			var mem = new MemoryStream(data);
-			mem.Seek(0, SeekOrigin.Begin);
-			return Deserialize(new StreamReader(mem));
-		}
+        public static JToken Deserialize(string sourceString)
+        {
+            var data = Encoding.UTF8.GetBytes(sourceString);
+            var mem = new MemoryStream(data);
+            mem.Seek(0, SeekOrigin.Begin);
+            return Deserialize(new StreamReader(mem));
+        }
 
-		public static JToken Deserialize(Stream sourceStream)
-		{
-			return Deserialize(new StreamReader(sourceStream));
-		}
+        public static JToken Deserialize(Stream sourceStream)
+        {
+            return Deserialize(new StreamReader(sourceStream));
+        }
 
-		public static JToken Deserialize(StreamReader sourceReader)
-		{
-			JToken result = null;
-			LexToken token;
-			token = GetNextToken(sourceReader);
-			switch (token.TType)
-			{
-				case TokenType.LBrace:
-					result = ParseObject(sourceReader, ref token);
-					if (token.TType == TokenType.RBrace)
-						token = GetNextToken(sourceReader);
-					else if (token.TType != TokenType.End && token.TType != TokenType.Error)
-						throw new Exception("unexpected content after end of object");
-					break;
-				case TokenType.LArray:
-					result = ParseArray(sourceReader, ref token);
-					if (token.TType == TokenType.RArray)
-						token = GetNextToken(sourceReader);
-					else if (token.TType != TokenType.End && token.TType != TokenType.Error)
-						throw new Exception("unexpected content after end of array");
-					break;
-				default:
-					throw new Exception("unexpected initial token in json parse");
-			}
-			if (token.TType != TokenType.End)
-				throw new Exception("unexpected end token in json parse");
-			else if (token.TType == TokenType.Error)
-				throw new Exception("unexpected lexical token during json parse");
-			return result;
-		}
+        public static JToken Deserialize(StreamReader sourceReader)
+        {
+            JToken result = null;
+            LexToken token;
+            token = GetNextToken(sourceReader);
+            switch (token.TType)
+            {
+                case TokenType.LBrace:
+                    result = ParseObject(sourceReader, ref token);
+                    if (token.TType == TokenType.RBrace)
+                        token = GetNextToken(sourceReader);
+                    else if (token.TType != TokenType.End && token.TType != TokenType.Error)
+                        throw new Exception("unexpected content after end of object");
+                    break;
+                case TokenType.LArray:
+                    result = ParseArray(sourceReader, ref token);
+                    if (token.TType == TokenType.RArray)
+                        token = GetNextToken(sourceReader);
+                    else if (token.TType != TokenType.End && token.TType != TokenType.Error)
+                        throw new Exception("unexpected content after end of array");
+                    break;
+                default:
+                    throw new Exception("unexpected initial token in json parse");
+            }
+            if (token.TType != TokenType.End)
+                throw new Exception("unexpected end token in json parse");
+            else if (token.TType == TokenType.Error)
+                throw new Exception("unexpected lexical token during json parse");
+            return result;
+        }
 
+#if (!MF_FRAMEWORK_VERSION_V4_3 && !MF_FRAMEWORK_VERSION_V4_4)
+        public static JToken FromBson(byte[] buffer, InstanceFactory factory = null)
+            {
+            var offset = 0;
+            var len = (Int32)SerializationUtilities.Unmarshall(buffer, ref offset, TypeCode.Int32);
+#else
         public static object FromBson(byte[] buffer, Type resultType, InstanceFactory factory = null)
         {
             int offset = 0;
             int len = (Int32)SerializationUtilities.Unmarshall(buffer, ref offset, TypeCode.Int32);
 
+#endif
             JToken dserResult = null;
             while (offset < buffer.Length - 1)
             {
@@ -290,310 +321,326 @@ namespace PervasiveDigital.Json
                         throw new Exception("unexpected top-level object type in bson");
                 }
             }
-            if (buffer[offset++]!=0)
+            if (buffer[offset++] != 0)
                 throw new Exception("bad format - missing trailing null on bson document");
+#if (!MF_FRAMEWORK_VERSION_V4_3 && !MF_FRAMEWORK_VERSION_V4_4)
             return PopulateObject(dserResult, resultType, "/", factory);
+#else
+            return dserResult;
+#endif
         }
 
-		private static JObject ParseObject(StreamReader sr, ref LexToken token)
-		{
-			Debug.Assert(token.TType == TokenType.LBrace);
-			var result = new JObject();
-			token = GetNextToken(sr);
-			while (token.TType != TokenType.End && token.TType != TokenType.Error && token.TType != TokenType.RBrace)
-			{
-				if (token.TType != TokenType.String)
-					throw new Exception("expected label");
-				var propName = token.TValue;
+#if (!MF_FRAMEWORK_VERSION_V4_3 && !MF_FRAMEWORK_VERSION_V4_4)
+        public static object FromBson(byte[] buffer, Type resultType, InstanceFactory factory = null)
+        {
+            var jtoken = FromBson(buffer);
+            return PopulateObject(jtoken, resultType, "/", factory);
+        }
+#endif
 
-				token = GetNextToken(sr);
-				if (token.TType != TokenType.Colon)
-					throw new Exception("expected colon");
+        private static JObject ParseObject(StreamReader sr, ref LexToken token)
+        {
+            Debug.Assert(token.TType == TokenType.LBrace);
+            var result = new JObject();
+            token = GetNextToken(sr);
+            while (token.TType != TokenType.End && token.TType != TokenType.Error && token.TType != TokenType.RBrace)
+            {
+                if (token.TType != TokenType.String)
+                    throw new Exception("expected label");
+                var propName = token.TValue;
 
-				var value = ParseValue(sr, ref token);
-				result.Add(propName, value);
+                token = GetNextToken(sr);
+                if (token.TType != TokenType.Colon)
+                    throw new Exception("expected colon");
 
-				token = GetNextToken(sr);
-				if (token.TType == TokenType.Comma)
-					token = GetNextToken(sr);
+                var value = ParseValue(sr, ref token);
+                result.Add(propName, value);
 
-			};
-			if (token.TType == TokenType.Error)
-				throw new Exception("unexpected token in json object");
-			else if (token.TType != TokenType.RBrace)
-				throw new Exception("unterminated json object");
-			return result;
-		}
+                token = GetNextToken(sr);
+                if (token.TType == TokenType.Comma)
+                    token = GetNextToken(sr);
 
-		private static JArray ParseArray(StreamReader sr, ref LexToken token)
-		{
-			Debug.Assert(token.TType == TokenType.LArray || token.TType == TokenType.RArray);
-			ArrayList list = new ArrayList();
-			while (token.TType != TokenType.End && token.TType != TokenType.Error && token.TType != TokenType.RArray)
-			{
-				var value = ParseValue(sr, ref token);
-				if (value != null)
-				{
-					list.Add(value);
-					token = GetNextToken(sr);
-					if (token.TType != TokenType.Comma && token.TType != TokenType.RArray)
-						throw new Exception("badly formed array");
-				}
-			};
-			if (token.TType == TokenType.Error)
-				throw new Exception("unexpected token in array");
-			else if (token.TType != TokenType.RArray)
-				throw new Exception("unterminated json array");
-			var result = new JArray((JToken[])list.ToArray(typeof(JToken)));
-			return result;
-		}
+            };
+            if (token.TType == TokenType.Error)
+                throw new Exception("unexpected token in json object");
+            else if (token.TType != TokenType.RBrace)
+                throw new Exception("unterminated json object");
+            return result;
+        }
 
-		private static JToken ParseValue(StreamReader sr, ref LexToken token)
-		{
-			token = GetNextToken(sr);
-			if (token.TType == TokenType.RArray)
-			{
-				// we were expecting a value in an array, and came across the end-of-array marker,
-				//  so this is an empty array
-				return null;
-			}
-			else if (token.TType == TokenType.String)
-				return new JValue(token.TValue);
-			else if (token.TType == TokenType.Number)
-			{
-				if (token.TValue.IndexOfAny(new char[] { '.', 'e', 'E' }) != -1)
-					return new JValue(double.Parse(token.TValue));
-				else
-					return new JValue(int.Parse(token.TValue));
-			}
-			else if (token.TType == TokenType.True)
-				return new JValue(true);
-			else if (token.TType == TokenType.False)
-				return new JValue(false);
-			else if (token.TType == TokenType.Null)
-				return new JValue(null);
-			else if (token.TType == TokenType.Date)
-			{
-				throw new NotSupportedException("datetime parsing not supported");
-			}
-			else if (token.TType == TokenType.LBrace)
-				return ParseObject(sr, ref token);
-			else if (token.TType == TokenType.LArray)
-				return ParseArray(sr, ref token);
+        private static JArray ParseArray(StreamReader sr, ref LexToken token)
+        {
+            Debug.Assert(token.TType == TokenType.LArray || token.TType == TokenType.RArray);
+            ArrayList list = new ArrayList();
+            while (token.TType != TokenType.End && token.TType != TokenType.Error && token.TType != TokenType.RArray)
+            {
+                var value = ParseValue(sr, ref token);
+                if (value != null)
+                {
+                    list.Add(value);
+                    token = GetNextToken(sr);
+                    if (token.TType != TokenType.Comma && token.TType != TokenType.RArray)
+                        throw new Exception("badly formed array");
+                }
+            };
+            if (token.TType == TokenType.Error)
+                throw new Exception("unexpected token in array");
+            else if (token.TType != TokenType.RArray)
+                throw new Exception("unterminated json array");
+            var result = new JArray((JToken[])list.ToArray(typeof(JToken)));
+            return result;
+        }
 
-			throw new Exception("invalid value found during json parse");
-		}
+        private static JToken ParseValue(StreamReader sr, ref LexToken token)
+        {
+            token = GetNextToken(sr);
+            if (token.TType == TokenType.RArray)
+            {
+                // we were expecting a value in an array, and came across the end-of-array marker,
+                //  so this is an empty array
+                return null;
+            }
+            else if (token.TType == TokenType.String)
+                return new JValue(token.TValue);
+            else if (token.TType == TokenType.Number)
+            {
+                if (token.TValue.IndexOfAny(new char[] { '.', 'e', 'E' }) != -1)
+                    return new JValue(double.Parse(token.TValue));
+                else
+                    return new JValue(int.Parse(token.TValue));
+            }
+            else if (token.TType == TokenType.True)
+                return new JValue(true);
+            else if (token.TType == TokenType.False)
+                return new JValue(false);
+            else if (token.TType == TokenType.Null)
+                return new JValue(null);
+            else if (token.TType == TokenType.Date)
+            {
+                throw new NotSupportedException("datetime parsing not supported");
+            }
+            else if (token.TType == TokenType.LBrace)
+                return ParseObject(sr, ref token);
+            else if (token.TType == TokenType.LArray)
+                return ParseArray(sr, ref token);
 
-		private static LexToken GetNextToken(StreamReader sourceReader)
+            throw new Exception("invalid value found during json parse");
+        }
+
+        private static LexToken GetNextToken(StreamReader sourceReader)
 #if DEBUG
-		{
-			// a diagnostic wrapper, used only in debug builds
-			var result = GetNextTokenInternal(sourceReader);
+        {
+            // a diagnostic wrapper, used only in debug builds
+            var result = GetNextTokenInternal(sourceReader);
+#if (!MF_FRAMEWORK_VERSION_V4_3 && !MF_FRAMEWORK_VERSION_V4_4)
+            Debug.WriteLine(result.TType.TokenTypeToString());
+#else
 			Debug.Print(result.TType.TokenTypeToString());
-			if (result.TType == TokenType.String || result.TType == TokenType.Number)
+#endif
+            			if (result.TType == TokenType.String || result.TType == TokenType.Number)
 				Debug.Print("    " + result.TValue);
 			return result;
-		}
+        }
 
-		private static LexToken GetNextTokenInternal(StreamReader sourceReader)
+        private static LexToken GetNextTokenInternal(StreamReader sourceReader)
 #endif
-		{
-			StringBuilder sb = null;
-			char openQuote = '\0';
+        {
+            StringBuilder sb = null;
+            char openQuote = '\0';
 
-			char ch = ' ';
-			while (true) // EndOfStream doesn't seem to work for mem streams - it's always 'true'
-			{
-				ch = (char)sourceReader.Read();
+            char ch = ' ';
+            while (true) // EndOfStream doesn't seem to work for mem streams - it's always 'true'
+            {
+                ch = (char)sourceReader.Read();
 
-				// Handle json escapes
-				bool escaped = false;
-				if (ch == '\\')
-				{
-					escaped = true;
-					ch = (char)sourceReader.Read();
-					if (ch == (char)0xffff)
-						return EndToken(sb);
-					//TODO: replace with a mapping array? This switch is really incomplete.
-					switch (ch)
-					{
-						case '\'':
-							ch = '\'';
-							break;
-						case '"':
-							ch = '"';
-							break;
-						case 't':
-							ch = '\t';
-							break;
-						case 'r':
-							ch = '\r';
-							break;
-						case 'n':
-							ch = '\n';
-							break;
-						default:
-							throw new Exception("unsupported escape");
-					}
-				}
+                // Handle json escapes
+                bool escaped = false;
+                if (ch == '\\')
+                {
+                    escaped = true;
+                    ch = (char)sourceReader.Read();
+                    if (ch == (char)0xffff)
+                        return EndToken(sb);
+                    //TODO: replace with a mapping array? This switch is really incomplete.
+                    switch (ch)
+                    {
+                        case '\'':
+                            ch = '\'';
+                            break;
+                        case '"':
+                            ch = '"';
+                            break;
+                        case 't':
+                            ch = '\t';
+                            break;
+                        case 'r':
+                            ch = '\r';
+                            break;
+                        case 'n':
+                            ch = '\n';
+                            break;
+                        default:
+                            throw new Exception("unsupported escape");
+                    }
+                }
 
-				if (sb != null && (ch != openQuote || escaped))
-				{
-					sb.Append(ch);
-				}
-				else if (IsNumberIntroChar(ch))
-				{
-					sb = new StringBuilder();
-					while (IsNumberChar(ch))
-					{
-						sb.Append(ch);
-						// Don't consume chars that are not part of the number
-						ch = (char)sourceReader.Peek();
-						if (IsNumberChar(ch))
-							sourceReader.Read();
+                if (sb != null && (ch != openQuote || escaped))
+                {
+                    sb.Append(ch);
+                }
+                else if (IsNumberIntroChar(ch))
+                {
+                    sb = new StringBuilder();
+                    while (IsNumberChar(ch))
+                    {
+                        sb.Append(ch);
+                        // Don't consume chars that are not part of the number
+                        ch = (char)sourceReader.Peek();
+                        if (IsNumberChar(ch))
+                            sourceReader.Read();
 
-						if (ch == (char)0xffff)
-							return EndToken(sb);
-					}
-					// Note that we don't claim that this is a well-formed number
-					return new LexToken() { TType = TokenType.Number, TValue = sb.ToString() };
-				}
-				else
-				{
-					switch (ch)
-					{
-						case '{':
-							return new LexToken() { TType = TokenType.LBrace, TValue = null };
-						case '}':
-							return new LexToken() { TType = TokenType.RBrace, TValue = null };
-						case '[':
-							return new LexToken() { TType = TokenType.LArray, TValue = null };
-						case ']':
-							return new LexToken() { TType = TokenType.RArray, TValue = null };
-						case ':':
-							return new LexToken() { TType = TokenType.Colon, TValue = null };
-						case ',':
-							return new LexToken() { TType = TokenType.Comma, TValue = null };
-						case '"':
-						case '\'':
-							if (sb == null)
-							{
-								openQuote = ch;
-								sb = new StringBuilder();
-							}
-							else
-							{
-								// We're building a string and we hit a quote character.
-								// The ch must match openQuote, or otherwise we should have eaten it above as string content
-								Debug.Assert(ch == openQuote);
-								return new LexToken() { TType = TokenType.String, TValue = sb.ToString() };
-							}
-							break;
-						case ' ':
-						case '\t':
-						case '\r':
-						case '\n':
-							break; // whitespace - go around again
-						case (char)0xffff:
-							return EndToken(sb);
-						default:
-							// try to collect a token
-							switch (ch.ToLower())
-							{
-								case 't':
-									Expect(sourceReader, 'r');
-									Expect(sourceReader, 'u');
-									Expect(sourceReader, 'e');
-									return new LexToken() { TType = TokenType.True, TValue = null };
-								case 'f':
-									Expect(sourceReader, 'a');
-									Expect(sourceReader, 'l');
-									Expect(sourceReader, 's');
-									Expect(sourceReader, 'e');
-									return new LexToken() { TType = TokenType.False, TValue = null };
-								case 'n':
-									Expect(sourceReader, 'u');
-									Expect(sourceReader, 'l');
-									Expect(sourceReader, 'l');
-									return new LexToken() { TType = TokenType.Null, TValue = null };
-								default:
-									throw new Exception("unexpected character during json lexical parse");
-							}
-					}
-				}
-			}
-		}
+                        if (ch == (char)0xffff)
+                            return EndToken(sb);
+                    }
+                    // Note that we don't claim that this is a well-formed number
+                    return new LexToken() { TType = TokenType.Number, TValue = sb.ToString() };
+                }
+                else
+                {
+                    switch (ch)
+                    {
+                        case '{':
+                            return new LexToken() { TType = TokenType.LBrace, TValue = null };
+                        case '}':
+                            return new LexToken() { TType = TokenType.RBrace, TValue = null };
+                        case '[':
+                            return new LexToken() { TType = TokenType.LArray, TValue = null };
+                        case ']':
+                            return new LexToken() { TType = TokenType.RArray, TValue = null };
+                        case ':':
+                            return new LexToken() { TType = TokenType.Colon, TValue = null };
+                        case ',':
+                            return new LexToken() { TType = TokenType.Comma, TValue = null };
+                        case '"':
+                        case '\'':
+                            if (sb == null)
+                            {
+                                openQuote = ch;
+                                sb = new StringBuilder();
+                            }
+                            else
+                            {
+                                // We're building a string and we hit a quote character.
+                                // The ch must match openQuote, or otherwise we should have eaten it above as string content
+                                Debug.Assert(ch == openQuote);
+                                return new LexToken() { TType = TokenType.String, TValue = sb.ToString() };
+                            }
+                            break;
+                        case ' ':
+                        case '\t':
+                        case '\r':
+                        case '\n':
+                            break; // whitespace - go around again
+                        case (char)0xffff:
+                            return EndToken(sb);
+                        default:
+                            // try to collect a token
+                            switch (ch.ToLower())
+                            {
+                                case 't':
+                                    Expect(sourceReader, 'r');
+                                    Expect(sourceReader, 'u');
+                                    Expect(sourceReader, 'e');
+                                    return new LexToken() { TType = TokenType.True, TValue = null };
+                                case 'f':
+                                    Expect(sourceReader, 'a');
+                                    Expect(sourceReader, 'l');
+                                    Expect(sourceReader, 's');
+                                    Expect(sourceReader, 'e');
+                                    return new LexToken() { TType = TokenType.False, TValue = null };
+                                case 'n':
+                                    Expect(sourceReader, 'u');
+                                    Expect(sourceReader, 'l');
+                                    Expect(sourceReader, 'l');
+                                    return new LexToken() { TType = TokenType.Null, TValue = null };
+                                default:
+                                    throw new Exception("unexpected character during json lexical parse");
+                            }
+                    }
+                }
+            }
+        }
 
-		private static void Expect(StreamReader sr, char ch)
-		{
-			if (((char)sr.Read()).ToLower() != ch)
-				throw new Exception("unexpected character during json lexical parse");
-		}
+        private static void Expect(StreamReader sr, char ch)
+        {
+            if (((char)sr.Read()).ToLower() != ch)
+                throw new Exception("unexpected character during json lexical parse");
+        }
 
-		private static bool IsValidTokenChar(char ch)
-		{
-			return (ch >= 'a' && ch <= 'z') ||
-				   (ch >= 'A' && ch <= 'Z') ||
-				   (ch >= '0' && ch <= '9');
-		}
+        private static bool IsValidTokenChar(char ch)
+        {
+            return (ch >= 'a' && ch <= 'z') ||
+                   (ch >= 'A' && ch <= 'Z') ||
+                   (ch >= '0' && ch <= '9');
+        }
 
-		private static LexToken EndToken(StringBuilder sb)
-		{
-			if (sb != null)
-				return new LexToken() { TType = TokenType.Error, TValue = null };
-			else
-				return new LexToken() { TType = TokenType.End, TValue = null };
-		}
+        private static LexToken EndToken(StringBuilder sb)
+        {
+            if (sb != null)
+                return new LexToken() { TType = TokenType.Error, TValue = null };
+            else
+                return new LexToken() { TType = TokenType.End, TValue = null };
+        }
 
-		// Legal first characters for numbers
-		private static bool IsNumberIntroChar(char ch)
-		{
-			return (ch == '-') || (ch == '+') || (ch == '.') || (ch >= '0' & ch <= '9');
-		}
+        // Legal first characters for numbers
+        private static bool IsNumberIntroChar(char ch)
+        {
+            return (ch == '-') || (ch == '+') || (ch == '.') || (ch >= '0' & ch <= '9');
+        }
 
-		// Legal chars for 2..n'th position of a number
-		private static bool IsNumberChar(char ch)
-		{
-			return (ch == '-') || (ch == '+') || (ch == '.') || (ch == 'e') || (ch == 'E') || (ch >= '0' & ch <= '9');
-		}
+        // Legal chars for 2..n'th position of a number
+        private static bool IsNumberChar(char ch)
+        {
+            return (ch == '-') || (ch == '+') || (ch == '.') || (ch == 'e') || (ch == 'E') || (ch >= '0' & ch <= '9');
+        }
 
 #if DEBUG
-		private static string TokenTypeToString(this TokenType val)
-		{
-			switch (val)
-			{
-				case TokenType.Colon:
-					return "COLON";
-				case TokenType.Comma:
-					return "COMMA";
-				case TokenType.Date:
-					return "DATE";
-				case TokenType.End:
-					return "END";
-				case TokenType.Error:
-					return "ERROR";
-				case TokenType.LArray:
-					return "LARRAY";
-				case TokenType.LBrace:
-					return "LBRACE";
-				case TokenType.Number:
-					return "NUMBER";
-				case TokenType.RArray:
-					return "RARRAY";
-				case TokenType.RBrace:
-					return "RBRACE";
-				case TokenType.String:
-					return "STRING";
-				case TokenType.Null:
-					return "NULL";
-				case TokenType.True:
-					return "TRUE";
-				case TokenType.False:
-					return "FALSE";
-				default:
-					return "??unknown??";
-			}
-		}
+        private static string TokenTypeToString(this TokenType val)
+        {
+            switch (val)
+            {
+                case TokenType.Colon:
+                    return "COLON";
+                case TokenType.Comma:
+                    return "COMMA";
+                case TokenType.Date:
+                    return "DATE";
+                case TokenType.End:
+                    return "END";
+                case TokenType.Error:
+                    return "ERROR";
+                case TokenType.LArray:
+                    return "LARRAY";
+                case TokenType.LBrace:
+                    return "LBRACE";
+                case TokenType.Number:
+                    return "NUMBER";
+                case TokenType.RArray:
+                    return "RARRAY";
+                case TokenType.RBrace:
+                    return "RBRACE";
+                case TokenType.String:
+                    return "STRING";
+                case TokenType.Null:
+                    return "NULL";
+                case TokenType.True:
+                    return "TRUE";
+                case TokenType.False:
+                    return "FALSE";
+                default:
+                    return "??unknown??";
+            }
+        }
 #endif
-	}
+    }
 }

--- a/src/JsonNetmf/JsonNetmf.Shared/SerializationUtilities.cs
+++ b/src/JsonNetmf/JsonNetmf.Shared/SerializationUtilities.cs
@@ -1,13 +1,17 @@
-﻿using System;
+using System;
 using System.Text;
 
+#if (MF_FRAMEWORK_VERSION_V4_3 || MF_FRAMEWORK_VERSION_V4_4)
 namespace PervasiveDigital.Json
+#else
+namespace GHIElectronics.TinyCLR.Data.Json
+#endif
 {
-	public static class SerializationUtilities
-	{
-		public static void Marshall(byte[] buffer, ref int offset, object arg)
-		{
-			var type = arg.GetType();
+    public static class SerializationUtilities
+    {
+        public static void Marshall(byte[] buffer, ref int offset, object arg)
+        {
+            var type = arg.GetType();
             if (type == typeof(byte))
             {
                 buffer[offset++] = (byte)arg;
@@ -79,67 +83,94 @@ namespace PervasiveDigital.Json
                 offset += length;
                 buffer[offset++] = 0;
             }
+
+#if (!MF_FRAMEWORK_VERSION_V4_3 && !MF_FRAMEWORK_VERSION_V4_4!)
+            else if (type == typeof(float))
+            {
+                var bytes = BitConverter.GetBytes((double)((float)arg));
+                foreach (var b in bytes)
+                {
+                    buffer[offset++] = b;
+                }
+            }
+            else if (type == typeof(double))
+            {
+                var bytes = BitConverter.GetBytes((double)arg);
+                foreach (var b in bytes)
+                {
+                    buffer[offset++] = b;
+                }
+            }
+#endif
             else
                 throw new Exception("unsupported type for Marshall");
-		}
+        }
 
-		public static object Unmarshall(byte[] buffer, ref int offset, TypeCode tc)
-		{
-			object result = null;
-			switch (tc)
-			{
-				case TypeCode.Empty: // secret code for the argument typecode array
-					var argCount = (int)buffer[offset++];
-					var tcArray = new TypeCode[argCount];
-					for (var i = 0; i < argCount; ++i)
-					{
-						tcArray[i] = (TypeCode)buffer[offset++];
-					}
-					result = tcArray;
-					break;
-				case TypeCode.Byte:
-					result = buffer[offset++];
-					break;
-				case TypeCode.Int16:
-					result = (Int16)(buffer[offset] | buffer[offset + 1] << 8);
-					offset += 2;
-					break;
-				case TypeCode.UInt16:
-					result = (UInt16)(buffer[offset] | buffer[offset + 1] << 8);
-					offset += 2;
-					break;
-				case TypeCode.Int32:
-					result = (Int32)(buffer[offset] | buffer[offset + 1] << 8 | buffer[offset + 2] << 16 | buffer[offset + 3] << 24);
-					offset += 4;
-					break;
-				case TypeCode.UInt32:
-					result = (UInt32)(buffer[offset] | buffer[offset + 1] << 8 | buffer[offset + 2] << 16 | buffer[offset + 3] << 24);
-					offset += 4;
-					break;
-				case TypeCode.Int64:
-					result = (Int64)(((UInt64)buffer[offset]) | ((UInt64)buffer[offset + 1]) << 8 | ((UInt64)buffer[offset + 2]) << 16 | ((UInt64)buffer[offset + 3]) << 24 |
-									 ((UInt64)buffer[offset + 4]) << 32 | ((UInt64)buffer[offset + 5]) << 40 | ((UInt64)buffer[offset + 6]) << 48 | ((UInt64)buffer[offset + 7]) << 56);
-					offset += 8;
-					break;
-				case TypeCode.UInt64:
-					result = (UInt64)(((UInt64)buffer[offset]) | ((UInt64)buffer[offset + 1]) << 8 | ((UInt64)buffer[offset + 2]) << 16 | ((UInt64)buffer[offset + 3]) << 24 |
-									 ((UInt64)buffer[offset + 4]) << 32 | ((UInt64)buffer[offset + 5]) << 40 | ((UInt64)buffer[offset + 6]) << 48 | ((UInt64)buffer[offset + 7]) << 56);
-					offset += 8;
-					break;
-				case TypeCode.DateTime:
-					result = new DateTime((long)Unmarshall(buffer, ref offset, TypeCode.Int64));
-					break;
-				case TypeCode.String:
+        public static object Unmarshall(byte[] buffer, ref int offset, TypeCode tc)
+        {
+            object result = null;
+            switch (tc)
+            {
+                case TypeCode.Empty: // secret code for the argument typecode array
+                    var argCount = (int)buffer[offset++];
+                    var tcArray = new TypeCode[argCount];
+                    for (var i = 0; i < argCount; ++i)
+                    {
+                        tcArray[i] = (TypeCode)buffer[offset++];
+                    }
+                    result = tcArray;
+                    break;
+                case TypeCode.Byte:
+                    result = buffer[offset++];
+                    break;
+                case TypeCode.Int16:
+                    result = (Int16)(buffer[offset] | buffer[offset + 1] << 8);
+                    offset += 2;
+                    break;
+                case TypeCode.UInt16:
+                    result = (UInt16)(buffer[offset] | buffer[offset + 1] << 8);
+                    offset += 2;
+                    break;
+                case TypeCode.Int32:
+                    result = (Int32)(buffer[offset] | buffer[offset + 1] << 8 | buffer[offset + 2] << 16 | buffer[offset + 3] << 24);
+                    offset += 4;
+                    break;
+                case TypeCode.UInt32:
+                    result = (UInt32)(buffer[offset] | buffer[offset + 1] << 8 | buffer[offset + 2] << 16 | buffer[offset + 3] << 24);
+                    offset += 4;
+                    break;
+                case TypeCode.Int64:
+                    result = (Int64)(((UInt64)buffer[offset]) | ((UInt64)buffer[offset + 1]) << 8 | ((UInt64)buffer[offset + 2]) << 16 | ((UInt64)buffer[offset + 3]) << 24 |
+                                     ((UInt64)buffer[offset + 4]) << 32 | ((UInt64)buffer[offset + 5]) << 40 | ((UInt64)buffer[offset + 6]) << 48 | ((UInt64)buffer[offset + 7]) << 56);
+                    offset += 8;
+                    break;
+                case TypeCode.UInt64:
+                    result = (UInt64)(((UInt64)buffer[offset]) | ((UInt64)buffer[offset + 1]) << 8 | ((UInt64)buffer[offset + 2]) << 16 | ((UInt64)buffer[offset + 3]) << 24 |
+                                     ((UInt64)buffer[offset + 4]) << 32 | ((UInt64)buffer[offset + 5]) << 40 | ((UInt64)buffer[offset + 6]) << 48 | ((UInt64)buffer[offset + 7]) << 56);
+                    offset += 8;
+                    break;
+                case TypeCode.DateTime:
+                    result = new DateTime((long)Unmarshall(buffer, ref offset, TypeCode.Int64));
+                    break;
+                case TypeCode.String:
                     var idxNul = JToken.FindNul(buffer, offset);
                     if (idxNul == -1)
                         throw new Exception("Missing ename terminator");
                     result = JToken.ConvertToString(buffer, offset, idxNul - offset);
                     offset = idxNul + 1;
-					break;
-				default:
-					throw new Exception("Unsupported type");
-			}
-			return result;
-		}
-	}
+                    break;
+#if (!MF_FRAMEWORK_VERSION_V4_3 && !MF_FRAMEWORK_VERSION_V4_4)
+                case TypeCode.Double:
+                    var i64 = (Int64)(((UInt64)buffer[offset]) | ((UInt64)buffer[offset + 1]) << 8 | ((UInt64)buffer[offset + 2]) << 16 | ((UInt64)buffer[offset + 3]) << 24 |
+                                     ((UInt64)buffer[offset + 4]) << 32 | ((UInt64)buffer[offset + 5]) << 40 | ((UInt64)buffer[offset + 6]) << 48 | ((UInt64)buffer[offset + 7]) << 56);
+                    result = BitConverter.Int64BitsToDouble(i64);
+                    offset += 8;
+                    break;
+#endif
+                default:
+                    throw new Exception("Unsupported type");
+            }
+            return result;
+        }
+    }
 }

--- a/src/JsonNetmf/JsonNetmf.Shared/StringExtensions.cs
+++ b/src/JsonNetmf/JsonNetmf.Shared/StringExtensions.cs
@@ -1,9 +1,13 @@
 ﻿using System;
 using System.Text;
 
+#if (MF_FRAMEWORK_VERSION_V4_3 || MF_FRAMEWORK_VERSION_V4_4)
 namespace PervasiveDigital.Json
+#else
+namespace GHIElectronics.TinyCLR.Data.Json
+#endif
 {
-    internal static class StringExtensions
+	internal static class StringExtensions
     {
 		public static bool Contains(this string source, string search)
 		{

--- a/src/JsonNetmf/JsonNetmf.Shared/TimeExtensions.cs
+++ b/src/JsonNetmf/JsonNetmf.Shared/TimeExtensions.cs
@@ -1,10 +1,11 @@
-﻿// (c) Pervasive Digital LLC
-// Use of this code and resulting binaries is permitted only under the
-// terms of a written license.
 using System;
+#if (MF_FRAMEWORK_VERSION_V4_3 || MF_FRAMEWORK_VERSION_V4_4)
 using Microsoft.SPOT;
 
 namespace PervasiveDigital.Json
+#else
+namespace GHIElectronics.TinyCLR.Data.Json
+#endif
 {
 	public static class DateTimeExtensions
 	{
@@ -130,7 +131,11 @@ namespace PervasiveDigital.Json
 			if (utc)
 			{
 				// Convert the Kind to DateTimeKind.Utc if string Z present
+#if (MF_FRAMEWORK_VERSION_V4_3 || MF_FRAMEWORK_VERSION_V4_4)
 				dt = new DateTime(0, DateTimeKind.Utc).AddTicks(dt.Ticks);
+#else
+				dt = new DateTime(dt.Ticks, DateTimeKind.Utc);
+#endif
 			}
 
 			return dt;
@@ -142,7 +147,7 @@ namespace PervasiveDigital.Json
 		/// </summary>
 		/// <param name="dt"></param>
 		/// <returns></returns>
-		public static string ToIso8601(DateTime dt)
+        public static string ToIso8601(DateTime dt)
 		{
 			string result = dt.Year.ToString() + "-" +
 							TwoDigits(dt.Month) + "-" +


### PR DESCRIPTION
 (as found at: https://github.com/ghi-electronics/TinyCLR-Libraries/tree/dev/GHIElectronics.TinyCLR.Data.Json)
whilst keeping compatibility with netMF as per your original intentions.

Allows continued development for nanoFramework support as outlined in #1 .
(although I gladly bring back/ add an appropriate header to include (c) PervasiveDigital, Licensed under apache 2, if the issue is answered),

Note: some changes are probably backwards compatible with netMF, however these have been excluded as no test environment for either platforms is currently available.
